### PR TITLE
Fix: rename function to erase mail use reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * @param {object} [config=settings()] configurations for the template string interpolation
  * @returns {string} interpolated or processed template string
  */
-const processMail = (template, values, config = settings()) => {
+const processTemplate = (template, values, config = settings()) => {
   // destructuring configurations
   const {openingbracket, closingbracket, trim} = config
 
@@ -88,4 +88,4 @@ const settings = () => {
   }
 }
 
-module.exports = processMail
+module.exports = processTemplate

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "templatestringparser",
+  "version": "1.0.5",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "templatestringparser",
+      "version": "1.0.5",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
1.Changed the name of the `processMail` function to close #3  